### PR TITLE
Add require for usage of class Vagrant::Util::PowerShell

### DIFF
--- a/plugins/commands/ps/command.rb
+++ b/plugins/commands/ps/command.rb
@@ -1,6 +1,7 @@
 require "optparse"
 
 require_relative "../../communicators/winrm/helper"
+require_relative "../../../lib/vagrant/util/powershell"
 
 module VagrantPlugins
   module CommandPS


### PR DESCRIPTION
Without this require if would throw at me:

```
vagrant/plugins/commands/ps/command.rb:92:in `ready_ps_remoting_for': uninitialized constant Vagrant::Util::PowerShell (NameError)
```
